### PR TITLE
Update inst.rst (Removed "AMD IPU Driver>= 10.105.5.42" as a prerequisite)

### DIFF
--- a/docs/inst.rst
+++ b/docs/inst.rst
@@ -43,8 +43,7 @@ To enable the development and deployment of IPU-based inference on the client de
      - version >= 3.9 
    * - Anaconda or Miniconda
      - Latest version
-   * - AMD IPU driver
-     - >= 10.105.5.42
+
 
 |
 |


### PR DESCRIPTION
Removed "AMD IPU Driver>= 10.105.5.42" as a prerequisite older driver not work with latest one-step installer as per https://github.com/amd/RyzenAI-SW/issues/25