### PR TITLE
Set environment variable for canonical URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,11 @@ html_last_updated_fmt = 'February 12, 2024'
 
 # -- General configuration ---------------------------------------------------
 
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "ryzenai.docs.amd.com")
+html_context = {}
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'


### PR DESCRIPTION
Closes https://github.com/amd/ryzen-ai-documentation/issues/287

IMPORTANT: Required by Oct 7, 2024

due to Removal of Sphinx context injection at build time

https://about.readthedocs.com/blog/2024/07/addons-by-default/