### PR TITLE
Fix broken links

### DIFF
--- a/docs/app_development.rst
+++ b/docs/app_development.rst
@@ -19,7 +19,7 @@ The application should only use the Vitis AI Execution Provider if the following
 - The application is running on an AMD processor with a :ref:`NPU type supported by the version of the Vitis AI EP<apu-types>` being used.
 - :ref:`NPU drivers compatible with the version of the Vitis AI EP <driver-compatibility>` being used are installed.
 
-|memo| **NOTE**: Sample C++ code implementing the compatibility checks to be performed before using the VitisAI EP is provided here: https://github.com/amd/RyzenAI-SW/tree/main/utilities_tools
+|memo| **NOTE**: Sample C++ code implementing the compatibility checks to be performed before using the VitisAI EP is provided here: https://github.com/amd/RyzenAI-SW/tree/main/utilities/npu_check
 
 The application is responsible for setting the NPU configuration (set the XLNX_VART_FIRMWARE environment variable) correctly according to the APU type.
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -22,7 +22,7 @@ NPU
 iGPU
 ~~~~
 
-- `ResNet50 on iGPU <https://github.com/amd/RyzenAI-SW/tree/main/iGPU/getting_started>`_
+- `ResNet50 on iGPU <https://github.com/amd/RyzenAI-SW/tree/main/example/iGPU/getting_started>`_
 
 
 ************************************

--- a/docs/gpu/ryzenai_gpu.rst
+++ b/docs/gpu/ryzenai_gpu.rst
@@ -8,7 +8,7 @@ Prerequisites
 
 - DirectX12 capable Windows OS (Windows 11 recommended)
 - Latest AMD `GPU device driver <https://www.amd.com/en/support>`_ installed
-- `Microsoft Olive <https://microsoft.github.io/Olive/getstarted/installation.html#>`_ for model conversion and optimization
+- `Microsoft Olive <https://microsoft.github.io/Olive/how-to/installation.html>`_ for model conversion and optimization
 - Latest `ONNX Runtime DirectML EP <https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html>`_ 
 
 You can ensure GPU driver and DirectX version from ``Windows Task Manager`` -> ``Performance`` -> ``GPU`` 
@@ -33,7 +33,7 @@ For additional information, refer to the `ONNX Runtime documentation for the Dir
 Examples
 ********
 
-- Optimizing and running `ResNet on Ryzen AI GPU <https://github.com/amd/RyzenAI-SW/tree/main/iGPU/getting_started>`_
+- Optimizing and running `ResNet on Ryzen AI GPU <https://github.com/amd/RyzenAI-SW/tree/main/example/iGPU/getting_started>`_
 
 
 ********************

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -124,7 +124,7 @@ Version 1.2
 
 - New Demos:
   
-  - NPU-GPU multi-model pipeline application `demo <https://github.com/amd/RyzenAI-SW/tree/main/demo/multi-model-exec>`_
+  - NPU-GPU multi-model pipeline application `demo <https://github.com/amd/RyzenAI-SW/tree/main/demo/NPU-GPU-Pipeline>`_
 
 - NPU and Compiler
   


### PR DESCRIPTION
In addition to fixes in the PR, there are three more broken links that the file does not exist: https://ryzenai.docs.amd.com/en/latest/oga_flow.html is missing for links in "New Model Support for OGA Flow" on https://ryzenai.docs.amd.com/en/latest/relnotes.html

