### PR TITLE
Updated Lemonade links to Lemonade SDK repo

### DIFF
--- a/docs/llm/high_level_python.rst
+++ b/docs/llm/high_level_python.rst
@@ -10,7 +10,7 @@
 High-Level Python SDK
 #####################
 
-A Python environment offers flexibility for experimenting with LLMs, profiling them, and integrating them into Python applications. We use the `Lemonade SDK <https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/README.md>`_ to get up and running quickly.
+A Python environment offers flexibility for experimenting with LLMs, profiling them, and integrating them into Python applications. We use the `Lemonade SDK <https://github.com/lemonade-sdk/lemonade>`_ to get up and running quickly.
 
 To get started, follow these instructions.
 
@@ -35,8 +35,7 @@ To create and set up an environment, run these commands in your terminal:
 
     conda create -n ryzenai-llm python=3.10
     conda activate ryzenai-llm
-    pip install turnkeyml[llm-oga-hybrid]
-    lemonade-install --ryzenai hybrid
+    pip install lemonade-sdk[llm]
 
 ****************
 Validation Tools

--- a/docs/llm/overview.rst
+++ b/docs/llm/overview.rst
@@ -73,7 +73,7 @@ The Server Interface provides a convenient means to integrate with applications 
 
 To get started with the server interface, follow these instructions: :doc:`server_interface`.
 
-For example applications that have been tested with Lemonade Server, see the `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server>`_.
+For example applications that have been tested with Lemonade Server, see the `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server/apps>`_.
 
 
 OGA APIs for C++ Libraries and Python

--- a/docs/llm/overview.rst
+++ b/docs/llm/overview.rst
@@ -73,7 +73,7 @@ The Server Interface provides a convenient means to integrate with applications 
 
 To get started with the server interface, follow these instructions: :doc:`server_interface`.
 
-For example applications that have been tested with Lemonade Server, see the `Lemonade Server Examples <https://github.com/onnx/turnkeyml/tree/main/examples/lemonade/server>`_.
+For example applications that have been tested with Lemonade Server, see the `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server>`_.
 
 
 OGA APIs for C++ Libraries and Python
@@ -170,7 +170,7 @@ The comprehensive set of pre-optimized models for hybrid execution used in these
      - 8.9x
      - 🟢
 
-The :ref:`ryzen-ai-oga-featured-llms` table was compiled using validation, benchmarking, and accuracy metrics as measured by the `ONNX TurnkeyML v6.1.0 <https://pypi.org/project/turnkeyml/6.1.0/>`_ ``lemonade`` commands in each example link.
+The :ref:`ryzen-ai-oga-featured-llms` table was compiled using validation, benchmarking, and accuracy metrics as measured by the `ONNX TurnkeyML v6.1.0 <https://pypi.org/project/turnkeyml/6.1.0/>`_ ``lemonade`` commands in each example link. After this table was created, the Lemonade SDK moved to the new location found `here <https://github.com/lemonade-sdk/lemonade>`_.
 
 Data collection details:
 

--- a/docs/llm/server_interface.rst
+++ b/docs/llm/server_interface.rst
@@ -23,10 +23,10 @@ Server Setup
 Lemonade Server can be installed via the Lemonade Server Installer executable by following these steps:
 
 1. Make sure your system has the recommended Ryzen AI driver installed as described in :ref:`install-driver`.
-2. Download and install ``Lemonade_Server_Installer.exe`` from the `latest TurnkeyML release <https://github.com/onnx/turnkeyml/releases>`_.
+2. Download and install ``Lemonade_Server_Installer.exe`` from the `latest Lemonade release <https://github.com/lemonade-sdk/lemonade/releases>`_.
 3. Launch the server by double-clicking the ``lemonade_server`` shortcut added to your desktop.
 
-See the `Lemonade Server Installation Guide <https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/lemonade_server_exe.md>`_ for more details.
+See the `Lemonade Server Installation Guide <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/README.md>`_ for more details.
 
 ************
 Server Usage
@@ -38,7 +38,7 @@ The Lemonade Server provides the following OpenAI-compatible endpoints:
 - POST ``/api/v0/completions`` - Text Completions (prompt to completion)
 - GET ``/api/v0/models`` - List available models
 
-Please refer to the `server specification <https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/server_spec.md>`_ document in the Lemonade repository for details about the request and response formats for each endpoint. 
+Please refer to the `server specification <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/server_spec.md>`_ document in the Lemonade repository for details about the request and response formats for each endpoint. 
 
 The `OpenAI API documentation <https://platform.openai.com/docs/guides/streaming-responses?api-mode=chat>`_ also has code examples for integrating streaming completions into an application. 
 
@@ -75,8 +75,8 @@ Instructions:
 Next Steps
 **********
 
-- See `Lemonade Server Examples <https://github.com/onnx/turnkeyml/tree/main/examples/lemonade/server>`_ to find applications that have been tested with Lemonade Server.
-- Check out the `Lemonade Server specification <https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/server_spec.md>`_ to learn more about supported features.
+- See `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server>`_ to find applications that have been tested with Lemonade Server.
+- Check out the `Lemonade Server specification <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/server_spec.md>`_ to learn more about supported features.
 - Try out your Lemonade Server install with any application that uses the OpenAI chat completions API.
 
 

--- a/docs/llm/server_interface.rst
+++ b/docs/llm/server_interface.rst
@@ -26,7 +26,7 @@ Lemonade Server can be installed via the Lemonade Server Installer executable by
 2. Download and install ``Lemonade_Server_Installer.exe`` from the `latest Lemonade release <https://github.com/lemonade-sdk/lemonade/releases>`_.
 3. Launch the server by double-clicking the ``lemonade_server`` shortcut added to your desktop.
 
-See the `Lemonade Server Installation Guide <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/README.md>`_ for more details.
+See the `Lemonade Server README <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/README.md>`_ for more details.
 
 ************
 Server Usage

--- a/docs/llm/server_interface.rst
+++ b/docs/llm/server_interface.rst
@@ -75,7 +75,7 @@ Instructions:
 Next Steps
 **********
 
-- See `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server>`_ to find applications that have been tested with Lemonade Server.
+- See `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server/apps>`_ to find applications that have been tested with Lemonade Server.
 - Check out the `Lemonade Server specification <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/server_spec.md>`_ to learn more about supported features.
 - Try out your Lemonade Server install with any application that uses the OpenAI chat completions API.
 


### PR DESCRIPTION
Recently, the Lemonade SDK moved from https://github.com/onnx/turnkeyml to its own dedicated repo at https://github.com/lemonade-sdk/lemonade. Updating the Ryzen AI docs to point to the new location. 