### PR TITLE
Updated Lemonade links to Lemonade SDK repo 

### DIFF
--- a/docs/llm/high_level_python.rst
+++ b/docs/llm/high_level_python.rst
@@ -10,7 +10,7 @@
 High-Level Python SDK
 #####################
 
-A Python environment offers flexibility for experimenting with LLMs, profiling them, and integrating them into Python applications. We use the `Lemonade SDK <https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/README.md>`_ to get up and running quickly.
+A Python environment offers flexibility for experimenting with LLMs, profiling them, and integrating them into Python applications. We use the `Lemonade SDK <https://github.com/lemonade-sdk/lemonade>`_ to get up and running quickly.
 
 To get started, follow these instructions.
 
@@ -35,8 +35,7 @@ To create and set up an environment, run these commands in your terminal:
 
     conda create -n ryzenai-llm python=3.10
     conda activate ryzenai-llm
-    pip install turnkeyml[llm-oga-hybrid]
-    lemonade-install --ryzenai hybrid
+    pip install lemonade-sdk[llm]
 
 ****************
 Validation Tools

--- a/docs/llm/overview.rst
+++ b/docs/llm/overview.rst
@@ -73,7 +73,7 @@ The Server Interface provides a convenient means to integrate with applications 
 
 To get started with the server interface, follow these instructions: :doc:`server_interface`.
 
-For example applications that have been tested with Lemonade Server, see the `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server>`_.
+For example applications that have been tested with Lemonade Server, see the `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server/apps>`_.
 
 
 OGA APIs for C++ Libraries and Python

--- a/docs/llm/overview.rst
+++ b/docs/llm/overview.rst
@@ -73,7 +73,7 @@ The Server Interface provides a convenient means to integrate with applications 
 
 To get started with the server interface, follow these instructions: :doc:`server_interface`.
 
-For example applications that have been tested with Lemonade Server, see the `Lemonade Server Examples <https://github.com/onnx/turnkeyml/tree/main/examples/lemonade/server>`_.
+For example applications that have been tested with Lemonade Server, see the `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server>`_.
 
 
 OGA APIs for C++ Libraries and Python
@@ -170,7 +170,7 @@ The comprehensive set of pre-optimized models for hybrid execution used in these
      - 8.9x
      - 🟢
 
-The :ref:`ryzen-ai-oga-featured-llms` table was compiled using validation, benchmarking, and accuracy metrics as measured by the `ONNX TurnkeyML v6.1.0 <https://pypi.org/project/turnkeyml/6.1.0/>`_ ``lemonade`` commands in each example link.
+The :ref:`ryzen-ai-oga-featured-llms` table was compiled using validation, benchmarking, and accuracy metrics as measured by the `ONNX TurnkeyML v6.1.0 <https://pypi.org/project/turnkeyml/6.1.0/>`_ ``lemonade`` commands in each example link. After this table was created, the Lemonade SDK moved to the new location found `here <https://github.com/lemonade-sdk/lemonade>`_.
 
 Data collection details:
 

--- a/docs/llm/server_interface.rst
+++ b/docs/llm/server_interface.rst
@@ -23,10 +23,10 @@ Server Setup
 Lemonade Server can be installed via the Lemonade Server Installer executable by following these steps:
 
 1. Make sure your system has the recommended Ryzen AI driver installed as described in :ref:`install-driver`.
-2. Download and install ``Lemonade_Server_Installer.exe`` from the `latest TurnkeyML release <https://github.com/onnx/turnkeyml/releases>`_.
+2. Download and install ``Lemonade_Server_Installer.exe`` from the `latest Lemonade release <https://github.com/lemonade-sdk/lemonade/releases>`_.
 3. Launch the server by double-clicking the ``lemonade_server`` shortcut added to your desktop.
 
-See the `Lemonade Server Installation Guide <https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/lemonade_server_exe.md>`_ for more details.
+See the `Lemonade Server Installation Guide <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/README.md>`_ for more details.
 
 ************
 Server Usage
@@ -38,7 +38,7 @@ The Lemonade Server provides the following OpenAI-compatible endpoints:
 - POST ``/api/v0/completions`` - Text Completions (prompt to completion)
 - GET ``/api/v0/models`` - List available models
 
-Please refer to the `server specification <https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/server_spec.md>`_ document in the Lemonade repository for details about the request and response formats for each endpoint. 
+Please refer to the `server specification <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/server_spec.md>`_ document in the Lemonade repository for details about the request and response formats for each endpoint. 
 
 The `OpenAI API documentation <https://platform.openai.com/docs/guides/streaming-responses?api-mode=chat>`_ also has code examples for integrating streaming completions into an application. 
 
@@ -75,8 +75,8 @@ Instructions:
 Next Steps
 **********
 
-- See `Lemonade Server Examples <https://github.com/onnx/turnkeyml/tree/main/examples/lemonade/server>`_ to find applications that have been tested with Lemonade Server.
-- Check out the `Lemonade Server specification <https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/server_spec.md>`_ to learn more about supported features.
+- See `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server>`_ to find applications that have been tested with Lemonade Server.
+- Check out the `Lemonade Server specification <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/server_spec.md>`_ to learn more about supported features.
 - Try out your Lemonade Server install with any application that uses the OpenAI chat completions API.
 
 

--- a/docs/llm/server_interface.rst
+++ b/docs/llm/server_interface.rst
@@ -26,7 +26,7 @@ Lemonade Server can be installed via the Lemonade Server Installer executable by
 2. Download and install ``Lemonade_Server_Installer.exe`` from the `latest Lemonade release <https://github.com/lemonade-sdk/lemonade/releases>`_.
 3. Launch the server by double-clicking the ``lemonade_server`` shortcut added to your desktop.
 
-See the `Lemonade Server Installation Guide <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/README.md>`_ for more details.
+See the `Lemonade Server README <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/README.md>`_ for more details.
 
 ************
 Server Usage

--- a/docs/llm/server_interface.rst
+++ b/docs/llm/server_interface.rst
@@ -75,7 +75,7 @@ Instructions:
 Next Steps
 **********
 
-- See `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server>`_ to find applications that have been tested with Lemonade Server.
+- See `Lemonade Server Examples <https://github.com/lemonade-sdk/lemonade/tree/main/docs/server/apps>`_ to find applications that have been tested with Lemonade Server.
 - Check out the `Lemonade Server specification <https://github.com/lemonade-sdk/lemonade/blob/main/docs/server/server_spec.md>`_ to learn more about supported features.
 - Try out your Lemonade Server install with any application that uses the OpenAI chat completions API.
 

--- a/docs/npu_oga.rst
+++ b/docs/npu_oga.rst
@@ -54,11 +54,11 @@ NPU Execution of OGA Models
 Setup
 =====
 
-Activate the Ryzen AI 1.4.1 Conda environment:
+Activate the Ryzen AI 1.4 Conda environment:
 
 .. code-block:: 
     
-    conda activate ryzen-ai-1.4.1
+    conda activate ryzen-ai-1.4.0
 
 Create a folder to run the LLMs from, and copy the required files:
 
@@ -69,15 +69,14 @@ Create a folder to run the LLMs from, and copy the required files:
   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\npu-llm\exe" .\libs
   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\npu-llm\libs\vaip_llm.json" libs
   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\npu-llm\onnxruntime-genai.dll" libs
-  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime_vitis_ai_custom_ops.dll" libs
-  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime_providers_shared.dll" libs
-  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime_vitisai_ep.dll" libs
-  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\dyn_dispatch_core.dll" libs
-  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime_providers_vitisai.dll" libs
-  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\transaction.dll" libs
-  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime.dll" libs
-  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\xclbin.dll" libs
-  xcopy /Y "%RYZEN_AI_INSTALLATION_PATH%\deployment\ryzen_mm.dll" libs
+  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime_vitis_ai_custom_ops.dll" libs
+  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime_providers_shared.dll" libs
+  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime_vitisai_ep.dll" libs
+  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\dyn_dispatch_core.dll" libs
+  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime_providers_vitisai.dll" libs
+  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\transaction.dll" libs
+  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime.dll" libs
+  xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\xclbin.dll" libs
 
 
 Download Models from HuggingFace
@@ -188,16 +187,15 @@ For example, for Llama-2-7b:
 
    :: Copy runtime dependencies in the "libs" folder
    xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\npu-llm\libs\vaip_llm.json" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime-genai.dll" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime_vitis_ai_custom_ops.dll" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime_providers_shared.dll" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime_vitisai_ep.dll" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\dyn_dispatch_core.dll" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime_providers_vitisai.dll" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\transaction.dll" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\onnxruntime.dll" libs
-   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\xclbin.dll" libs
-   xcopy /Y "%RYZEN_AI_INSTALLATION_PATH%\deployment\ryzen_mm.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\npu-llm\onnxruntime-genai.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime_vitis_ai_custom_ops.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime_providers_shared.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime_vitisai_ep.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\dyn_dispatch_core.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime_providers_vitisai.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\transaction.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\onnxruntime.dll" libs
+   xcopy /I "%RYZEN_AI_INSTALLATION_PATH%\deployment\voe\xclbin.dll" libs
 
 Sample Python Scripts
 =====================
@@ -212,21 +210,24 @@ In the model directory, open the ``genai_config.json`` file located in the folde
                 ...
       }
 
-To run LLMs, use the following command:
+To run LLMs other than ChatGLM, use the following command:
 
 .. code-block:: 
 
-     #To see available options and default setting:
-     python "%RYZEN_AI_INSTALLATION_PATH%\hybrid-llm\examples\python\run_model.py"
+     python "%RYZEN_AI_INSTALLATION_PATH%\hybrid-llm\examples\python\llama3\run_model.py" --model_dir <model folder>  
 
-     python "%RYZEN_AI_INSTALLATION_PATH%\hybrid-llm\examples\python\run_model.py" -m <model_folder> -l <max_token to be generated including prompt>
-  
+To run ChatGLM, use the following command:
+
+.. code-block:: 
+
+     pip install transformers==4.44.0  
+     python "%RYZEN_AI_INSTALLATION_PATH%\hybrid-llm\examples\python\chatglm\model-generate-chatglm3.py" -m <model folder>  
 
 For example, for Llama-2-7b:
 
 .. code-block::
    
-   python "%RYZEN_AI_INSTALLATION_PATH%\hybrid-llm\examples\python\run_model.py" -m "Llama-2-7b-hf-awq-g128-int4-asym-bf16-onnx-ryzen-strix" -l 128
+   python "%RYZEN_AI_INSTALLATION_PATH%\hybrid-llm\examples\python\llama3\run_model.py" --model_dir Llama-2-7b-hf-awq-g128-int4-asym-bf16-onnx-ryzen-strix
 
 
  

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -126,9 +126,11 @@ Version 1.4
 
 - Known Issues:
 
-  - LT might cause warnings or crashes when running concurrently with other MSFT Copilot apps
-  - Recall app might stop functioning; NPU driver and workloads are expected to continue to work
-  - Cocreator app does not close contexts quickly and might cause contexts to be limited due to remaining contexts still open
+  - Microsoft Windows Insider Program (WIP) users may see warnings or need to restart when running all applications concurrently. 
+  
+    - NPU driver and workloads will continue to work.
+
+  - Context creation may appear to be limited when some application do not close contexts quickly.
 
 
 ***********


### PR DESCRIPTION
Recently, the Lemonade SDK moved from https://github.com/onnx/turnkeyml to its own dedicated repo at https://github.com/lemonade-sdk/lemonade. Updating the Ryzen AI docs to point to the new location.

This PR syncs the hotfix into main with the develop branch.