### PR TITLE
Fix critical bug on high_level_python.rst

### DIFF
--- a/docs/llm/high_level_python.rst
+++ b/docs/llm/high_level_python.rst
@@ -36,6 +36,7 @@ To create and set up an environment, run these commands in your terminal:
     conda create -n ryzenai-llm python=3.10
     conda activate ryzenai-llm
     pip install lemonade-sdk[llm]
+    lemonade-install --ryzenai hybrid
 
 ****************
 Validation Tools


### PR DESCRIPTION
The `lemonade-install --ryzenai hybrid` was accidentally removed in the last PR, which causes the instructions to not work anymore.